### PR TITLE
更正package.json中关键词错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "keywords": [
     "微信支付",
     "微信红包",
-    "wehcat",
+    "wechat",
     "tenpay"
   ],
   "author": "Eric",


### PR DESCRIPTION
将 keywords 中 wehcat 更正为 wechat