### PR TITLE
申请退款接口失败时返回 解析好的json串，方便拿到错误原因err_code_des展示，而不是直接throw一个错误码err_code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,7 @@ class Payment {
 
     switch (type) {
       case 'middleware_nativePay':
+      case 'refund':
         break;
       default:
         if (json.return_code !== 'SUCCESS') throw new Error(json.return_msg || 'XMLDataError');
@@ -93,6 +94,7 @@ class Payment {
       case 'middleware_refund':
       case 'middleware_nativePay':
       case 'getsignkey':
+      case 'refund':
         break;
       default:
         if (json.result_code !== 'SUCCESS') throw new Error(json.err_code || 'XMLDataError');


### PR DESCRIPTION
当业务上发生失败时，尽量把微信的数据解析后透传给使用方，方便根据自己的业务特点对错误进行处理或提示